### PR TITLE
chore: bump resolver & dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 resolver = "2"
 
 [dependencies]
-unicode-width = { version = "0.1", optional = true }
+unicode-width = { version = "0.2", optional = true }
 
 [dev-dependencies]
 itertools = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Pig Fang <g-plane@hotmail.com>"]
 description = "Tiny implementation of Wadler-style pretty printer."
 repository = "https://github.com/g-plane/tiny_pretty"
 license = "MIT"
-resolver = "2"
+resolver = "3"
 
 [dependencies]
 unicode-width = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 unicode-width = { version = "0.2", optional = true }
 
 [dev-dependencies]
-itertools = "0.12"
+itertools = "0.14"
 
 [features]
 unicode-width = ["dep:unicode-width"]

--- a/src/print.rs
+++ b/src/print.rs
@@ -57,7 +57,7 @@ impl<'a> Printer<'a> {
                     let original_cols = self.cols;
 
                     let mut buf = String::new();
-                    if self.print_to((indent, mode, &attempt), &mut buf) {
+                    if self.print_to((indent, mode, attempt), &mut buf) {
                         // SAFETY: Both are `String`s.
                         unsafe {
                             out.as_mut_vec().append(buf.as_mut_vec());


### PR DESCRIPTION
Affects your dprint plugin integrations, because `dprint-core` uses `unicode-width@0.2` and this crate links to 0.1